### PR TITLE
Update `OAuthlib` to version `3.2.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
 
   run:
     - python >=3.6
-    - cryptography >=3.0.0,<4
+    - cryptography >=3.0.0
     - pyjwt >=2.0.0,<3
     - blinker >=1.4.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "oauthlib" %}
-{% set version = "3.1.1" %}
+{% set version = "3.2.0" %}
 {% set compress_type = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash = "8f0215fcc533dd8dd1bee6f4c412d4f0cd7297307d43ac61666389e3bc3198a3" %}
+{% set hash = "23a8208d75b902797ea29fd31fa80a15ed9dc2c6c16fe73f5d346f83f6fa27a2" %}
 {% set build = 0 %}
 
 package:


### PR DESCRIPTION
  `oauthlib` version `3.2.0`
1. - [x] check the upstream
    https://github.com/oauthlib/oauthlib/tree/v3.2.0

2. - [x] check the pinnings
 
   https://github.com/oauthlib/oauthlib/blob/v3.2.0/setup.py

    the minimal version of `python` supported is `3.6`
    https://github.com/oauthlib/oauthlib/blob/v3.2.0/setup.py#L37

3. - [x] check the changelogs

https://github.com/oauthlib/oauthlib/blob/v3.2.0/CHANGELOG.rst

Most of the changes mentioned were new features added

4. - [x] additional research
    https://github.com/conda-forge/oauthlib-feedstock/issues

    There are currently no open issues mentioned in `conda-forge`

5. - [x] verify dev_url
    https://github.com/idan/oauthlib

6. - [x] verify doc_url
    https://oauthlib.readthedocs.io

7. - [x] license is spdx compliant
8. - [x] license family
9. - [x] verify the build number
     the build number is set to zero
10. - [x] verify setuptools
     `setuptools` is on the recipe
11. - [x] verify wheel
     `wheel` is on the recipe
12. - [x] pip in the test section
     `pip` is on the recipe
13. - [x] veriy the test section

Results:
- All checks have passed


Based on the research findings and the results we can conclude
that it is safe to update `oauthlib` to version `3.2.0`
